### PR TITLE
Set A0 to Input Context when configure endpoint see 4.6.6

### DIFF
--- a/sys/arch/i386/include/ptrace.h
+++ b/sys/arch/i386/include/ptrace.h
@@ -1,4 +1,4 @@
-/*	$NetBSD: ptrace.h,v 1.18 2017/02/23 03:34:22 kamil Exp $	*/
+/*	$NetBSD: ptrace.h,v 1.19 2017/04/08 02:02:30 kamil Exp $	*/
 
 /*
  * Copyright (c) 2001 Wasabi Systems, Inc.
@@ -88,6 +88,8 @@
 #define	PT_SETXMMREGS		(PT_FIRSTMACH + 6)
 #define	PT_GETDBREGS		(PT_FIRSTMACH + 7)
 #define	PT_SETDBREGS		(PT_FIRSTMACH + 8)
+#define	PT_SETSTEP		(PT_FIRSTMACH + 9)
+#define	PT_CLEARSTEP		(PT_FIRSTMACH + 10)
 
 #define PT_MACHDEP_STRINGS \
 	"PT_STEP", \
@@ -98,7 +100,9 @@
 	"PT_GETXMMREGS", \
 	"PT_SETXMMREGS", \
 	"PT_GETDBREGS", \
-	"PT_SETDBREGS",
+	"PT_SETDBREGS", \
+	"PT_SETSTEP", \
+	"PT_CLEARSTEP",
 
 
 #include <machine/reg.h>

--- a/sys/dev/usb/xhci.c
+++ b/sys/dev/usb/xhci.c
@@ -614,7 +614,7 @@ xhci_detach(struct xhci_softc *sc, int flags)
 
 	kmem_free(sc->sc_slots, sizeof(*sc->sc_slots) * sc->sc_maxslots);
 
-	kmem_free(sc->sc_ctlrportbus, 
+	kmem_free(sc->sc_ctlrportbus,
 	    howmany(sc->sc_maxports * sizeof(uint8_t), NBBY));
 	kmem_free(sc->sc_ctlrportmap, sc->sc_maxports * sizeof(int));
 
@@ -1348,6 +1348,7 @@ xhci_configure_endpoint(struct usbd_pipe *pipe)
 	const u_int dci = xhci_ep_get_dci(pipe->up_endpoint->ue_edesc);
 	struct xhci_trb trb;
 	usbd_status err;
+	uint32_t *cp;
 
 	XHCIHIST_FUNC(); XHCIHIST_CALLED();
 	DPRINTFN(4, "slot %u dci %u epaddr 0x%02x attr 0x%02x",
@@ -1360,6 +1361,10 @@ xhci_configure_endpoint(struct usbd_pipe *pipe)
 
 	/* set up context */
 	xhci_setup_ctx(pipe);
+
+	/* Enable SLOT Context A0 shall be set to '1' */
+	cp = xhci_slot_get_icv(sc, xs, XHCI_ICI_INPUT_CONTROL);
+	cp[1] |= htole32(XHCI_INCTX_1_ADD_MASK(0));
 
 	hexdump("input control context", xhci_slot_get_icv(sc, xs, 0),
 	    sc->sc_ctxsz * 1);


### PR DESCRIPTION
eXtensible Host Controller Interface Specification(rev 1.1), 4.6.6:

> A0 shall be set to ‘1’ and refer to section 6.2.2.2 for the Slot Context fields
> used by the Configure Endpoint Command.

I have seen that when I run netbsd on qemu with usbhost **nec-usb-xhci**